### PR TITLE
Add: Nushell の設定管理を dotfiles に統合した

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ chmod +x install.sh
 
 ```bash
 ls -l ~/.config/nushell/config.nu ~/.config/nushell/env.nu
-nu -c 'version'
+nu -i -c 'exit'
 ```
 
 `nu` 起動時に設定読込エラーが出ないことを確認してください.

--- a/config/nushell/config.nu
+++ b/config/nushell/config.nu
@@ -6,5 +6,10 @@
 # 例: 次のような設定がある場合です.
 #   $env.config = ($env.config | upsert hooks.pre_prompt [ {|| ls } ])
 #
-# ls を停止するには pre_prompt を空にします (他にも入れている場合は ls のみ除去します).
-$env.config = ($env.config | upsert hooks.pre_prompt [])
+# ls を停止するには, pre_prompt から ls の hook のみを除去します.
+let pre_prompt_hooks = ($env.config.hooks.pre_prompt? | default [])
+let filtered_hooks = ($pre_prompt_hooks | where {|hook|
+  let hook_text = ($hook | to nuon --serialize | str trim | str replace '"' "")
+  not ($hook_text =~ '^\{\|\|\s*ls(\s+[^}]*)?\s*\}$')
+})
+$env.config = ($env.config | upsert hooks.pre_prompt $filtered_hooks)

--- a/config/nushell/env.nu
+++ b/config/nushell/env.nu
@@ -8,7 +8,13 @@
 def pretty_pwd [] {
   let home = $nu.home-dir
   let pwd  = $env.PWD
-  let shown = if ($pwd | str starts-with $home) { $pwd | str replace $home "~" } else { $pwd }
+  let shown = if ($pwd == $home) {
+    "~"
+  } else if ($pwd | str starts-with $"($home)/") {
+    $pwd | str replace $home "~"
+  } else {
+    $pwd
+  }
 
   if ($shown == "~") {
     "~"
@@ -66,7 +72,9 @@ def git_block [] {
     let ahead = if (($ab_parts | length) > 2) { $ab_parts | get 2 | str replace "+" "" | into int } else { 0 }
     let behind = if (($ab_parts | length) > 3) { $ab_parts | get 3 | str replace "-" "" | into int } else { 0 }
 
-    let tracked = ($lines | where {|l| ($l | str starts-with "1 ") or ($l | str starts-with "2 ") })
+    let tracked = ($lines | where {|l|
+      ($l | str starts-with "1 ") or ($l | str starts-with "2 ") or ($l | str starts-with "u ")
+    })
     let staged = ($tracked | where {|l|
       let cols = ($l | split row " " | where {|x| not ($x | is-empty) })
       let xy = if (($cols | length) > 1) { $cols | get 1 } else { ".." }

--- a/install.sh
+++ b/install.sh
@@ -16,15 +16,21 @@ link() {
   local dst="$2"
 
   if [ ! -e "$src" ] && [ ! -L "$src" ]; then
-    echo "skip (missing source): $src"
-    return 0
+    echo "error (missing source): $src" >&2
+    return 1
   fi
 
   mkdir -p "$(dirname "$dst")"
 
-  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
-    echo "already linked: $dst -> $src"
-    return 0
+  if [ -L "$dst" ]; then
+    local src_real=""
+    local dst_real=""
+    src_real="$(readlink -f "$src" 2>/dev/null || true)"
+    dst_real="$(readlink -f "$dst" 2>/dev/null || true)"
+    if [ -n "$src_real" ] && [ -n "$dst_real" ] && [ "$src_real" = "$dst_real" ]; then
+      echo "already linked: $dst -> $src"
+      return 0
+    fi
   fi
 
   backup "$dst"


### PR DESCRIPTION
## 概要
- Nushell 設定 (`config.nu`, `env.nu`) を dotfiles 管理へ追加
- `install.sh` で `~/.config/nushell/` への symlink 作成を実装
- `README.md` に導入手順と検証手順を追加

## 検証
- `bash -n install.sh`
- `HOME=/tmp/dotfiles-nu-test4 ./install.sh`
- `HOME=/tmp/dotfiles-nu-test4 nu -c 'version'`

Closes #1
