### PR TITLE
Disable Nushell welcome banner on login shell

### DIFF
--- a/config/nushell/config.nu
+++ b/config/nushell/config.nu
@@ -6,6 +6,9 @@
 # 例: 次のような設定がある場合です.
 #   $env.config = ($env.config | upsert hooks.pre_prompt [ {|| ls } ])
 #
+# ログイン時の Welcome バナーを表示しないようにします.
+$env.config = ($env.config | upsert show_banner false)
+#
 # ls を停止するには, pre_prompt から ls の hook のみを除去します.
 let pre_prompt_hooks = ($env.config.hooks.pre_prompt? | default [])
 let filtered_hooks = ($pre_prompt_hooks | where {|hook|


### PR DESCRIPTION
## 概要
Nushell ログインシェル起動時の Welcome バナー表示を無効化しました.

## 変更内容
- `config/nushell/config.nu` に `show_banner = false` を追加.
- 既存の `hooks.pre_prompt` から `ls` hook を除去するロジックは維持.

## 検証
- `nu --config config/nushell/config.nu --env-config config/nushell/env.nu -c '$env.config.show_banner | to nuon --raw'` が `false` を返すことを確認.
- `nu --config config/nushell/config.nu --env-config config/nushell/env.nu -c 'print ok'` が成功することを確認.

Closes #7
