### PR TITLE
WezTerm: SSH ドメイン自動生成とワークスペース選択機能を追加

### DIFF
--- a/config/wezterm/README.md
+++ b/config/wezterm/README.md
@@ -1,0 +1,32 @@
+# WezTerm 設定
+
+## SSH 接続先の設定方法
+
+このリポジトリーの `wezterm.lua` は `wezterm.default_ssh_domains()` を使って `~/.ssh/config` から SSH 接続先を自動的に読み込みます.
+接続先のホスト名・アドレス・ユーザー名は `~/.ssh/config` に記述し, このリポジトリーには含めません.
+
+### ~/.ssh/config の記述例
+
+```
+Host myserver
+  HostName 192.168.1.100
+  User myuser
+```
+
+## SSH マルチプレクサーへの接続
+
+`~/.ssh/config` に Host を定義すると, 以下のコマンドで接続できます.
+
+```
+wezterm connect SSHMUX:myserver
+```
+
+`SSHMUX:<host>` はサーバー上で動いている WezTerm マルチプレクサーに接続します.
+サーバー上にワークスペースが 2 つ以上ある場合は, 接続直後に選択画面が自動表示されます.
+
+## ワークスペース操作
+
+| キー | 動作 |
+|------|------|
+| Alt+Shift+W | ワークスペース一覧を表示して切り替える |
+| Alt+W | 新しいワークスペースを名前をつけて作成する |

--- a/config/wezterm/README.md
+++ b/config/wezterm/README.md
@@ -28,5 +28,5 @@ wezterm connect SSHMUX:myserver
 
 | キー | 動作 |
 |------|------|
-| Alt+Shift+W | ワークスペース一覧を表示して切り替える |
-| Alt+W | 新しいワークスペースを名前をつけて作成する |
+| Ctrl+Shift+L | ワークスペース一覧を表示して切り替える |
+| Ctrl+Shift+W | 新しいワークスペースを名前をつけて作成する |

--- a/config/wezterm/wezterm.lua
+++ b/config/wezterm/wezterm.lua
@@ -261,17 +261,17 @@ config.harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' }
 -- 接続先のアドレスやユーザー名は ~/.ssh/config に記述し, このファイルには持たない.
 config.ssh_domains = wezterm.default_ssh_domains()
 
--- Alt+Shift+W: ワークスペース一覧を表示して切り替える.
+-- Ctrl+Shift+L: ワークスペース一覧を表示して切り替える.
 table.insert(config.keys, {
-  key = 'w',
-  mods = 'ALT|SHIFT',
+  key = 'l',
+  mods = 'CTRL|SHIFT',
   action = wezterm.action.ShowLauncherArgs { flags = 'WORKSPACES' },
 })
 
--- Alt+W: 新しいワークスペースを名前をつけて作成する.
+-- Ctrl+Shift+W: 新しいワークスペースを名前をつけて作成する.
 table.insert(config.keys, {
   key = 'w',
-  mods = 'ALT',
+  mods = 'CTRL|SHIFT',
   action = wezterm.action.PromptInputLine {
     description = 'Enter new workspace name',
     action = wezterm.action_callback(function(window, pane, line)

--- a/config/wezterm/wezterm.lua
+++ b/config/wezterm/wezterm.lua
@@ -257,4 +257,73 @@ config.enable_scroll_bar = true
 -- これらを無効化することで, 記号の見た目が勝手に変わる状況を避け, 等幅表示の予測可能性を優先します.
 config.harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' }
 
+-- SSH ドメインを ~/.ssh/config から自動生成する.
+-- 接続先のアドレスやユーザー名は ~/.ssh/config に記述し, このファイルには持たない.
+config.ssh_domains = wezterm.default_ssh_domains()
+
+-- Alt+Shift+W: ワークスペース一覧を表示して切り替える.
+table.insert(config.keys, {
+  key = 'w',
+  mods = 'ALT|SHIFT',
+  action = wezterm.action.ShowLauncherArgs { flags = 'WORKSPACES' },
+})
+
+-- Alt+W: 新しいワークスペースを名前をつけて作成する.
+table.insert(config.keys, {
+  key = 'w',
+  mods = 'ALT',
+  action = wezterm.action.PromptInputLine {
+    description = 'Enter new workspace name',
+    action = wezterm.action_callback(function(window, pane, line)
+      if line then
+        window:perform_action(
+          wezterm.action.SwitchToWorkspace { name = line },
+          pane
+        )
+      end
+    end),
+  },
+})
+
+-- wezterm connect でドメインに接続した直後に発火する.
+-- ワークスペースが複数あれば選択画面を表示する.
+wezterm.on('gui-attached', function(domain)
+  -- gui-attached 発火時点では GUI ウィンドウが未初期化のため,
+  -- 0 秒後に呼び出すことで現在のイベント処理を抜けてから実行させる.
+  wezterm.time.call_after(0, function()
+    local workspaces = wezterm.mux.get_workspace_names()
+    if #workspaces <= 1 then
+      return
+    end
+    local choices = {}
+    for _, ws in ipairs(workspaces) do
+      table.insert(choices, { id = ws, label = ws })
+    end
+    local active_workspace = wezterm.mux.get_active_workspace()
+    for _, window in ipairs(wezterm.mux.all_windows()) do
+      if window:get_workspace() == active_workspace then
+        local gui_win = window:gui_window()
+        if gui_win then
+          gui_win:perform_action(
+            wezterm.action.InputSelector {
+              title = 'Select workspace',
+              choices = choices,
+              action = wezterm.action_callback(function(win, pane, id, label)
+                if id then
+                  win:perform_action(
+                    wezterm.action.SwitchToWorkspace { name = id },
+                    pane
+                  )
+                end
+              end),
+            },
+            window:active_pane()
+          )
+        end
+        return
+      end
+    end
+  end)
+end)
+
 return config


### PR DESCRIPTION
## 概要

- `wezterm.default_ssh_domains()` を使い、`~/.ssh/config` から SSH 接続先を自動生成する
- `wezterm connect SSHMUX:<host>` 接続時にワークスペースが複数あれば選択画面を表示する
- サーバー情報 (IP・ユーザー名) は `~/.ssh/config` に委ね、`wezterm.lua` に含めない

## 変更内容

- `config/wezterm/wezterm.lua`:
  - `ssh_domains` を `default_ssh_domains()` で自動生成
  - `gui-attached` イベントでワークスペース選択画面を表示 (複数ワークスペース時のみ)
  - `Ctrl+Shift+L`: ワークスペース一覧表示・切り替え
  - `Ctrl+Shift+W`: 新規ワークスペース作成
- `config/wezterm/README.md`: SSH 接続設定と接続コマンド、ワークスペース操作方法をダミー値で記述 (インストール対象外)

## 検証

- `wezterm connect SSHMUX:<host>` でサーバーに接続し、ワークスペースが 2 つ以上の場合に選択画面が表示されることを確認
- ワークスペースが 1 つの場合は選択画面をスキップすることを確認

## 影響範囲 / リスク

- `~/.ssh/config` に `Host` エントリがない場合は `ssh_domains` が空になるだけで他の動作に影響なし
- `README.md` はシンボリックリンク対象外のためインストール操作で変化なし

## 関連 Issue

- Closes #26

*This comment was posted by AI Agent (model: claude-sonnet-4-6).*