### PR TITLE
Remove: AI Agent 署名からモデル名を削除した

### DIFF
--- a/agents/skills/development-flow/SKILL.md
+++ b/agents/skills/development-flow/SKILL.md
@@ -36,7 +36,7 @@ GitHub Issue を要求の起点とし, AI Agent が実装, 検証, git/gh 操作
 AI Agent が GitHub 上に投稿するすべてのテキスト (PR 本文, PR コメント, review thread への返答) の末尾に, 以下の署名を付けます.
 
 ```
-*This comment was posted by AI Agent (model: <モデル名>).*
+*This comment was posted by AI Agent.*
 ```
 
 ## スクリプト

--- a/agents/skills/development-flow/references/05_push_and_open_pr.md
+++ b/agents/skills/development-flow/references/05_push_and_open_pr.md
@@ -49,7 +49,7 @@
 ## 関連 Issue
 - Closes #<issue番号>
 
-*This comment was posted by AI Agent (model: <モデル名>).*
+*This comment was posted by AI Agent.*
 ```
 
 ## 原則


### PR DESCRIPTION
## 概要
- `development-flow` の AI Agent 署名から `(model: <モデル名>)` を削除し簡潔な表記に統一する

## 変更内容
- `agents/skills/development-flow/SKILL.md`: 署名の `(model: <モデル名>)` を削除
- `agents/skills/development-flow/references/05_push_and_open_pr.md`: 同上

## 検証
- 変更箇所が 2 ファイル 2 行のみであることを diff で確認済み

## 影響範囲 / リスク
- 既存の投稿済みコメントには影響なし
- 今後の AI Agent 投稿の署名フォーマットが変わるのみ

## 関連 Issue
- Closes #32

*This comment was posted by AI Agent.*