### PR TITLE
`05_push_and_open_pr.md` に `gh` コマンドの落とし穴と対処を追記した

### DIFF
--- a/agents/skills/development-flow/references/05_push_and_open_pr.md
+++ b/agents/skills/development-flow/references/05_push_and_open_pr.md
@@ -23,9 +23,13 @@
 - PR の内容をユーザーへ提示し, 認証を得ます.
     - PR タイトル, 本文, draft / ready の別を提示します.
 - ユーザーの認証後に PR を作成または更新します.
+    - タイトルにバッククォートを含む場合, `--title "..."` とダブルクォートで渡すとシェルがコマンド置換として解釈しタイトルが壊れる. 変数経由で渡す.
+      例: `TITLE='`foo.md` の修正' && gh pr create --title "$TITLE" ...`
 - ready PR の場合, レビュー依頼先をユーザーに確認します.
     - 「レビューを依頼するユーザーがいれば GitHub ユーザー名を教えてください」と尋ねます.
     - ユーザーが指定した場合は `bash ${CLAUDE_SKILL_DIR}/scripts/add_reviewer.sh <PR番号> <username>` で依頼します.
+      `gh pr edit` が `projectCards` の GraphQL エラーで失敗する場合は REST API を使う.
+      例: `gh api repos/<owner>/<repo>/pulls/<number> --method PATCH --field title='...' --jq '.title'`
     - 不要と回答した場合はスキップします.
 - Issue の `進捗` を更新します.
     - ready PR → `レビュー待ち`, draft PR → `ドラフトレビュー中`.


### PR DESCRIPTION
## 概要
- PR 作成・編集時に踏みやすい `gh` コマンドの問題 2 点を手順内の該当ステップに追記した.

## 変更内容
- `gh pr create --title` にバッククォートを含む場合の注意と変数経由での渡し方を追記.
- `gh pr edit` が `projectCards` の GraphQL エラーで失敗する場合の REST API 回避策を追記.

## 検証
- 変更後の `05_push_and_open_pr.md` を目視確認済み.

## 影響範囲 / リスク
- development-flow スキルのみ. 既存の手順の動作は変わらない.

## 関連 Issue
- Closes #34

*This comment was posted by AI Agent (model: claude-sonnet-4-6).*