### PR TITLE
cleanup.sh / create_worktree.sh が worktree 内から実行されると REPO_NAME が二重になるバグを修正する

### DIFF
--- a/agents/skills/development-flow/scripts/cleanup.sh
+++ b/agents/skills/development-flow/scripts/cleanup.sh
@@ -31,7 +31,10 @@ fi
 # PR のブランチ名を取得し, worktree パスを算出する.
 # スラッシュをハイフンに置換して, ファイルシステムで安全なパスを生成する.
 BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
-REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+# worktree 内から実行された場合でも正しいリポジトリ名を得るため,
+# --show-toplevel ではなく worktree list の先頭行 (メイン worktree) を使う.
+MAIN_REPO=$(git worktree list --porcelain | awk 'NR==1{print $2}')
+REPO_NAME=$(basename "$MAIN_REPO")
 BRANCH_SAFE="${BRANCH//\//-}"
 WORKTREE_PATH="$HOME/.worktrees/${REPO_NAME}-${BRANCH_SAFE}"
 
@@ -61,6 +64,7 @@ fi
 
 # 2. worktree を削除する.
 # 未コミットの変更がある場合は誤って消さないよう中断する.
+# worktree 削除後はカレントディレクトリが消えるため, 先にメインリポジトリへ移動する.
 echo ""
 echo "=== 2/4 worktree ==="
 if git worktree list --porcelain | grep -q "^worktree $WORKTREE_PATH$"; then
@@ -69,6 +73,7 @@ if git worktree list --porcelain | grep -q "^worktree $WORKTREE_PATH$"; then
         echo "Error: worktree has uncommitted changes. Aborting." >&2
         exit 1
     fi
+    cd "$MAIN_REPO"
     git worktree remove "$WORKTREE_PATH"
     echo "removed"
 else

--- a/agents/skills/development-flow/scripts/create_worktree.sh
+++ b/agents/skills/development-flow/scripts/create_worktree.sh
@@ -12,7 +12,9 @@ if [[ $# -lt 1 ]]; then
 fi
 
 BRANCH="$1"
-REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+# worktree 内から実行された場合でも正しいリポジトリ名を得るため,
+# --show-toplevel ではなく worktree list の先頭行 (メイン worktree) を使う.
+REPO_NAME=$(basename "$(git worktree list --porcelain | awk 'NR==1{print $2}')")
 BRANCH_SAFE="${BRANCH//\//-}"
 WORKTREE_PATH="$HOME/.worktrees/${REPO_NAME}-${BRANCH_SAFE}"
 


### PR DESCRIPTION
## 概要

- worktree 内から実行すると `git rev-parse --show-toplevel` が worktree のルートパスを返し, `REPO_NAME` が二重になるバグを修正した
- worktree 削除後にカレントディレクトリが消えて後続の git コマンドが失敗するバグも合わせて修正した

## 変更内容

- `cleanup.sh` / `create_worktree.sh`: `REPO_NAME` の取得を `git worktree list --porcelain` の先頭行から取得するよう変更
- `cleanup.sh`: worktree 削除前にメインリポジトリへ `cd` するよう変更

## 検証

- worktree 内から `cleanup.sh --yes <pr_number>` を実行し, 全4ステップが正常完了することを確認
- worktree パスが二重にならないことを確認

## 影響範囲 / リスク

- worktree 外 (メインリポジトリ) からの実行は従来通り動作する

## 関連 Issue

- Closes #33

*This comment was posted by AI Agent.*
