### PR TITLE
reply_review.sh から署名の自動付加を削除し呼び出し元が本文全体を組み立てる設計に変更する

### DIFF
--- a/agents/skills/development-flow/references/07_address_review.md
+++ b/agents/skills/development-flow/references/07_address_review.md
@@ -33,8 +33,13 @@
         - インライン review comment への返答は `gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies -f body="<返答文>"` を使います.
         - 採用 → 何をどう直したかと commit URL を返答します.
         - 非採用 / 別 Issue / 要件変更 → 理由と今後の扱いを返答します.
-        - 返答例:
-            - > ご指摘の箇所について...\n\nご指摘ありがとうございます. `Option<T>` を返すよう変更しました. 反映コミット: [`xxxxxx`](...).\n\n*This comment was posted by AI Agent.*
+        - コマンド例 (採用・コミットあり):
+            ```bash
+            bash ${CLAUDE_SKILL_DIR}/scripts/reply_review.sh 123 PRR_xxxx \
+              "ご指摘ありがとうございます. 〇〇を修正しました.
+
+*This comment was posted by AI Agent.*" --with-commit
+            ```
 - Issue の `完了条件` を実態に合わせて更新します.
     - スコープ変更が入る場合は, チェック状態だけを動かさず, 先に本文を更新します.
     - 新しい独立要求は現 Issue を肥大化させず, 後続 Issue に分離します.

--- a/agents/skills/development-flow/references/07_address_review.md
+++ b/agents/skills/development-flow/references/07_address_review.md
@@ -28,13 +28,13 @@
     - 該当 review thread または PR コメントへ quote reply で返答します.
         - レビュー本文を引用してから返答します (quote reply 形式).
         - `bash ${CLAUDE_SKILL_DIR}/scripts/reply_review.sh <PR番号> <review_node_id> "<返答文>"` で投稿します.
+        - `<返答文>` の末尾には必ず署名 `*This comment was posted by AI Agent.*` を含めます. スクリプトは署名を自動付加しません.
         - 変更を反映したコミットがある場合は `--with-commit` を付けると commit URL が自動で付加されます.
         - インライン review comment への返答は `gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies -f body="<返答文>"` を使います.
         - 採用 → 何をどう直したかと commit URL を返答します.
         - 非採用 / 別 Issue / 要件変更 → 理由と今後の扱いを返答します.
-        - 返答の末尾に AI Agent であることを示す注記を付けます.
         - 返答例:
-            - > ご指摘の箇所について...\n\nご指摘ありがとうございます. `Option<T>` を返すよう変更しました. 反映コミット: [`xxxxxx`](...). *This comment was posted by AI Agent (model: xxxx).*
+            - > ご指摘の箇所について...\n\nご指摘ありがとうございます. `Option<T>` を返すよう変更しました. 反映コミット: [`xxxxxx`](...).\n\n*This comment was posted by AI Agent.*
 - Issue の `完了条件` を実態に合わせて更新します.
     - スコープ変更が入る場合は, チェック状態だけを動かさず, 先に本文を更新します.
     - 新しい独立要求は現 Issue を肥大化させず, 後続 Issue に分離します.

--- a/agents/skills/development-flow/scripts/reply_review.sh
+++ b/agents/skills/development-flow/scripts/reply_review.sh
@@ -42,6 +42,4 @@ fi
 
 gh pr comment "$PR_NUMBER" --body "${QUOTED}
 
-${REPLY_BODY}${COMMIT_LINE}
-
-*This comment was posted by AI Agent (model: claude).*"
+${REPLY_BODY}${COMMIT_LINE}"


### PR DESCRIPTION
## 概要

- `reply_review.sh` がスクリプト内で署名を自動付加していたため, 呼び出し元が署名を含む本文を渡すと二重になる問題があった
- スクリプトから署名を削除し, 呼び出し元が本文全体 (署名含む) を組み立てる設計に変更した

## 変更内容

- `scripts/reply_review.sh`: 末尾の署名付加を削除
- `references/07_address_review.md`: 呼び出し時に署名を含めることを明記, 返答例を更新

## 検証

- スクリプトの署名付加コードが削除されていることを確認
- `07_address_review.md` の呼び出し例に署名が含まれていることを確認

## 影響範囲 / リスク

- `reply_review.sh` の呼び出し元は返答文に署名を含める必要がある

## 関連 Issue

- Closes #36

*This comment was posted by AI Agent.*
