### PR TITLE
opencode 設定ファイルを dotfiles に追加する

### DIFF
--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -4,6 +4,10 @@
   "permission": {
     "edit": "allow",
     "read": "allow",
-    "bash": "ask"
+    "bash": "ask",
+    "websearch": "ask"
+  },
+  "compaction": {
+    "prune": false
   }
 }

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -3,6 +3,7 @@
   "autoupdate": false,
   "permission": {
     "edit": "allow",
-    "read": "allow"
+    "read": "allow",
+    "bash": "ask"
   }
 }

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -1,14 +1,8 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "autoupdate": false,
   "permission": {
     "edit": "allow",
     "read": "allow"
   }
-  // 今後の設定追加例:
-  // "model": "anthropic/claude-sonnet-4-5",
-  // "small_model": "anthropic/claude-haiku-4-5",
-  // "autoupdate": true,
-  // "bash": { "*": "ask", "git *": "allow" },
-  // "formatter": true,
-  // "lsp": true,
 }

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "allow",
+    "read": "allow"
+  }
+  // 今後の設定追加例:
+  // "model": "anthropic/claude-sonnet-4-5",
+  // "small_model": "anthropic/claude-haiku-4-5",
+  // "autoupdate": true,
+  // "bash": { "*": "ask", "git *": "allow" },
+  // "formatter": true,
+  // "lsp": true,
+}

--- a/config/opencode/tui.jsonc
+++ b/config/opencode/tui.jsonc
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "attention": {
+    "enabled": true,
+    "notifications": true,
+    "sound": true
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -215,6 +215,7 @@ link_pairs=(
   "$DOT/config/nushell/config.nu" "$HOME/.config/nushell/config.nu"
   "$DOT/config/nushell/env.nu" "$HOME/.config/nushell/env.nu"
   "$DOT/config/opencode/opencode.jsonc" "$HOME/.config/opencode/opencode.jsonc"
+  "$DOT/config/opencode/tui.jsonc" "$HOME/.config/opencode/tui.jsonc"
   "$DOT/config/wezterm/wezterm.lua" "$HOME/.config/wezterm/wezterm.lua"
   "$DOT/config/git/config" "$HOME/.config/git/config"
   "$DOT/config/git/ignore" "$HOME/.config/git/ignore"

--- a/install.sh
+++ b/install.sh
@@ -214,6 +214,7 @@ ensure_gitconfig() {
 link_pairs=(
   "$DOT/config/nushell/config.nu" "$HOME/.config/nushell/config.nu"
   "$DOT/config/nushell/env.nu" "$HOME/.config/nushell/env.nu"
+  "$DOT/config/opencode/opencode.jsonc" "$HOME/.config/opencode/opencode.jsonc"
   "$DOT/config/wezterm/wezterm.lua" "$HOME/.config/wezterm/wezterm.lua"
   "$DOT/config/git/config" "$HOME/.config/git/config"
   "$DOT/config/git/ignore" "$HOME/.config/git/ignore"


### PR DESCRIPTION
## 概要

- opencode のグローバル設定ファイル (`~/.config/opencode/opencode.jsonc`) を dotfiles で管理し、`install.sh` で symlink して反映できるようにする。

## 変更内容

- `config/opencode/opencode.jsonc` を新規追加
  - `permission.edit`: `"allow"` — ファイル編集のたびに許可確認をスキップ
  - `permission.read`: `"allow"` — ファイル読み取りのたびに許可確認をスキップ
  - `autoupdate`: `false` — 自動更新を無効化
- `install.sh` の `link_pairs` に opencode のエントリを追加

## 検証

- `install.sh` 実行後、`~/.config/opencode/opencode.jsonc` が symlink として配置されることを確認する想定。

## 影響範囲 / リスク

- 既存の `~/.config/opencode/opencode.jsonc` がある場合、`install.sh` が退避 (backup) してから symlink を張るため旧設定は失われない。
- edit/read を allow に変更することでこれらの許可確認がスキップされるが、ローカル dotfiles 管理対象のためセキュリティリスクは低い。

## 関連 Issue

- Closes #50

*This comment was posted by AI Agent.*
