### PR TITLE
Nushell で opencode コマンドの PATH が解決されない問題を修正する

### DIFF
--- a/config/nushell/env.nu
+++ b/config/nushell/env.nu
@@ -9,7 +9,7 @@
 let npm_global_bin = ($nu.home-dir | path join ".npm-global" "bin" | path expand)
 $env.PATH = ($env.PATH | where {|it| ($it | path expand) != $npm_global_bin } | prepend $npm_global_bin)
 
-# `~/.bashrc` の `# opencode` ブロック (`export PATH=/home/saki/.opencode/bin:$PATH`) を `nu` でも再現します.
+# `~/.bashrc` の `# opencode` ブロック (`export PATH="$HOME/.opencode/bin:$PATH"`) を `nu` でも再現します.
 # `npm_global_bin` より後に prepend し, `opencode` を優先的に解決します.
 let opencode_bin = ($nu.home-dir | path join ".opencode" "bin" | path expand)
 $env.PATH = ($env.PATH | where {|it| ($it | path expand) != $opencode_bin } | prepend $opencode_bin)

--- a/config/nushell/env.nu
+++ b/config/nushell/env.nu
@@ -9,6 +9,11 @@
 let npm_global_bin = ($nu.home-dir | path join ".npm-global" "bin" | path expand)
 $env.PATH = ($env.PATH | where {|it| ($it | path expand) != $npm_global_bin } | prepend $npm_global_bin)
 
+# `~/.bashrc` の `# opencode` ブロック (`export PATH=/home/saki/.opencode/bin:$PATH`) を `nu` でも再現します.
+# `npm_global_bin` より後に prepend し, `opencode` を優先的に解決します.
+let opencode_bin = ($nu.home-dir | path join ".opencode" "bin" | path expand)
+$env.PATH = ($env.PATH | where {|it| ($it | path expand) != $opencode_bin } | prepend $opencode_bin)
+
 # PWD をホーム配下の場合は "~" に置換して返します.
 def pretty_pwd [] {
   let home = $nu.home-dir


### PR DESCRIPTION
## 本 PR に対応する Issue

Closes #72

## 本 PR で行った変更の概要

`config/nushell/env.nu` に, 既存の `npm_global_bin` を PATH の先頭へ追加する処理と同じパターンで, `~/.opencode/bin` を PATH の先頭へ追加する処理を追加した. `~/.bashrc` では `.npm-global/bin` を prepend した後に `.opencode/bin` を prepend しているため, 最終的な優先順位は `opencode/bin` > `npm-global/bin` > その他になる. nu でも同じ順序を再現するため, `npm_global_bin` の prepend 処理の後に `opencode_bin` の prepend 処理を追加した.

## 動作を確認する手順

1. 本ブランチをチェックアウトする.
2. `nu -n -c 'source config/nushell/env.nu; which opencode'` を実行し, `/home/saki/.opencode/bin/opencode` が返ることを確認する.
3. `nu -n -c 'source config/nushell/env.nu; opencode --version'` を実行し, バージョンが表示されることを確認する.
4. `nu -n -c 'source config/nushell/env.nu; $env.PATH | first 2'` を実行し, `/home/saki/.opencode/bin`, `/home/saki/.npm-global/bin` の順に並んでいることを確認する.

## テストの実行方法

実行コマンドと結果:

~~~
$ nu -n -c "source config/nushell/env.nu; which opencode"
╭───┬──────────┬────────────────────────────────────┬──────────╮
│ # │ command  │                 path                 │   type   │
├───┼──────────┼────────────────────────────────────┼──────────┤
│ 0 │ opencode │ /home/saki/.opencode/bin/opencode    │ external │
╰───┴──────────┴────────────────────────────────────┴──────────╯

$ nu -n -c "source config/nushell/env.nu; opencode --version"
1.17.6

$ nu -n -c "source config/nushell/env.nu; \$env.PATH | first 2"
╭───┬────────────────────────────╮
│ 0 │ /home/saki/.opencode/bin   │
│ 1 │ /home/saki/.npm-global/bin │
╰───┴────────────────────────────╯
~~~

*This comment was posted by AI Agent.*
